### PR TITLE
[IMP] Add oca_dependencies.txt and adjust .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,12 @@ addons:
 #     For wkhtmltopdf, see the env section below
 
 # Sometimes complicated website repos need Compass & SaSS:
-#before_install:
+before_install:
 #  - rvm install ruby --latest
 #  - gem install bootstrap-sass
 #  - gem install compass --pre
+#  Login to github with Quartile account
+   - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
 
 stages:
   - linting

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,21 @@
+# List the OCA project dependencies, one per line
+# Add a repository url and branch if you need a forked version
+#
+# Examples
+# ========
+#
+# To depend on the standard version of sale-workflow, use:
+# sale-workflow
+#
+# To explicitely give the URL of a fork, and still use the version specified in
+# .travis.yml, use:
+# sale-workflow https://github.com/OCA/sale-workflow
+#
+# To provide both the URL and a branch, use:
+# sale-workflow https://github.com/OCA/sale-workflow branchname
+#
+# To use a specific commit version, set the branch (required) and the
+# commit SHA to select:
+# sale-workflow https://github.com/OCA/sale-workflow branchname f848e37
+
+qrtl-private git@github.com:qrtl/qrtl-private.git 12.0

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -20,3 +20,4 @@
 
 qrtl-private https://github.com/qrtl/qrtl-private.git 12.0
 enterprise https://github.com/odoo/enterprise.git 12.0
+qrtl-custom https://github.com/qrtl/qrtl-custom.git 12.0

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -19,3 +19,5 @@
 # sale-workflow https://github.com/OCA/sale-workflow branchname f848e37
 
 qrtl-private https://github.com/qrtl/qrtl-private.git 12.0
+enterprise https://github.com:odoo/enterprise.git 12.0
+

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -19,4 +19,4 @@
 # sale-workflow https://github.com/OCA/sale-workflow branchname f848e37
 
 qrtl-private https://github.com/qrtl/qrtl-private.git 12.0
-enterprise https://github.com:odoo/enterprise.git 12.0
+enterprise https://github.com/odoo/enterprise.git 12.0

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -20,4 +20,3 @@
 
 qrtl-private https://github.com/qrtl/qrtl-private.git 12.0
 enterprise https://github.com:odoo/enterprise.git 12.0
-

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -18,4 +18,4 @@
 # commit SHA to select:
 # sale-workflow https://github.com/OCA/sale-workflow branchname f848e37
 
-qrtl-private git@github.com:qrtl/qrtl-private.git 12.0
+qrtl-private https://github.com/qrtl/qrtl-private.git 12.0


### PR DESCRIPTION
Related Slab Post:
https://qrtl.slab.com/posts/travis-ci-integrated-development-workflow-ien4rczz#external-repository-dependencies

It seems that we need to add the dependencies of `qrtl-private` with the HTTPs URLs agin here, it makes the `oca_dependencies.txt` looks a bit strange (depends on itself)
```
qrtl-private https://github.com/qrtl/qrtl-private.git 12.0
enterprise https://github.com/odoo/enterprise.git 12.0
qrtl-custom https://github.com/qrtl/qrtl-custom.git 12.0
```