### PR TITLE
[3685][FIX] hr_timesheet_unpropagate_project: _compute_project_id()

### DIFF
--- a/hr_timesheet_unpropagate_project/models/hr_timesheet.py
+++ b/hr_timesheet_unpropagate_project/models/hr_timesheet.py
@@ -8,9 +8,9 @@ class AccountAnalyticLine(models.Model):
     _inherit = "account.analytic.line"
 
     def _compute_project_id(self):
-        model = self._context.get("params", {}).get("model")
-        if model and model == "project.task":
-            # Avoid updating the project of existing timesheet records when project
-            # assignment is changed in the task.
-            return
-        super()._compute_project_id()
+        # Avoid updating the project of existing timesheet records which are already
+        # validated or not owned by the current user.
+        self = self.filtered(
+            lambda x: not x.validated and x.employee_id.user_id == self.env.user
+        )
+        return super()._compute_project_id()


### PR DESCRIPTION
[3685](https://www.quartile.co/web#id=3685&cids=3&menu_id=506&action=1457&model=project.task&view_type=form)

Before this commit, the issue of project propagation from updating task's project was still happening when user opens the task form via timesheet records.

This commit fixes the issue by not relying on the context value.
